### PR TITLE
Fix Vendor Prefix Grouping Regex

### DIFF
--- a/src/rules/use-defensive-css/index.test.js
+++ b/src/rules/use-defensive-css/index.test.js
@@ -222,6 +222,25 @@ testRule({
       description:
         'Split webkit and moz placeholder selectors to separate rules.',
     },
+    {
+      code: `div::before,div::after { color: #222; }`,
+      description:
+        'Combining pseudo elements with the same selector into one rule.',
+    },
+    {
+      code: `
+      .tabs-pink--active strong,
+      .tabs-pink--active svg,
+      .tabs-pink:hover strong,
+      .tab-type-2--active strong,
+      .tab-type-2--active svg,
+      .tab-type-2:hover strong,
+      .tab-resource-item:hover {
+          color: #e20072;
+      }`,
+      description:
+        'Combining a bunch of selectors into one rule. See: https://github.com/yuschick/stylelint-plugin-defensive-css/issues/4',
+    },
   ],
 
   reject: [

--- a/src/utils/findVendorPrefixes.js
+++ b/src/utils/findVendorPrefixes.js
@@ -1,9 +1,9 @@
-const expression = /-[-moz-|-ms-|-o-|-webkit-|]+-/g;
+const expression = /-[moz|ms|o|webkit|]+-/g;
 
 function findVendorPrefixes(selector) {
   if (!selector) return false;
 
-  let prefixesFound = [...selector.matchAll(expression)];
+  let prefixesFound = [...selector.trim().matchAll(expression)];
   return prefixesFound.length > 1;
 }
 


### PR DESCRIPTION
## 📒 Description

- updates the vendor prefix regex to prevent false positives

## 🚀 Changes

- updates the vendor prefix regex
- adds test coverage from provided repo reproducing the error

## 🔐 Closes

#4 

## ⛳️ Testing

- added the code snippets from the reproduction repo to ensure they no longer throw false positive errors
- ran `npm run test` to ensure all tests pass
