### PR TITLE
Add Support for Scroll Chaining Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,64 @@ div {
 }
 ```
 
+### Scroll Chaining
+
+> [Read more about this pattern in Defensive CSS](https://defensivecss.dev/tip/scroll-chaining/)
+
+Have you ever opened a modal and started scrolling, and then when you reach the
+end and keep scrolling, the content underneath the modal (the body element) will
+scroll? This is called scroll chaining.
+
+Enable this rule in order to require all scrollable overflow properties to have
+an overscroll-behavior value.
+
+```json
+{
+  "rules": {
+    "plugin/use-defensive-css": [true, { "scroll-chaining": true }]
+  }
+}
+```
+
+#### ✅ Passing Examples
+
+```css
+div {
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+}
+
+div {
+  overflow: hidden scroll;
+  overscroll-behavior: contain;
+}
+
+div {
+  overflow: hidden; /* No overscroll-behavior is needed in the case of hidden */
+}
+
+div {
+  overflow-block: auto;
+  overscroll-behavior: none;
+}
+```
+
+#### ❌ Failing Examples
+
+```css
+div {
+  overflow-x: auto;
+}
+
+div {
+  overflow: hidden scroll;
+}
+
+div {
+  overflow-block: auto;
+}
+```
+
 ### Vendor Prefix Grouping
 
 > [Read more about this pattern in Defensive CSS](https://defensivecss.dev/tip/grouping-selectors/)

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ div {
 
 ### Scroll Chaining
 
-> [Read more about this pattern in Defensive CSS](https://defensivecss.dev/tip/scroll-chaining/)
+> [Read more about this pattern in Defensive CSS](https://defensivecss.dev/tip/scroll-chain/)
 
 Have you ever opened a modal and started scrolling, and then when you reach the
 end and keep scrolling, the content underneath the modal (the body element) will

--- a/src/rules/use-defensive-css/base.js
+++ b/src/rules/use-defensive-css/base.js
@@ -14,6 +14,9 @@ const ruleMessages = stylelint.utils.ruleMessages(ruleName, {
   flexWrapping() {
     return 'Flex rows must have a `flex-wrap: wrap;` or `flex-wrap: wrap-reverse` declaration.';
   },
+  scrollChaining() {
+    return `Containers with an auto or scroll 'overflow' must also have an 'overscroll-behavior' property defined.`;
+  },
   vendorPrefixWGrouping() {
     return `Separate different vendor prefixes into their own rules.`;
   },

--- a/src/rules/use-defensive-css/index.test.js
+++ b/src/rules/use-defensive-css/index.test.js
@@ -215,6 +215,92 @@ testRule({
 /* eslint-disable-next-line no-undef  */
 testRule({
   ruleName,
+  config: [true, { 'scroll-chaining': true }],
+  plugins: ['./index.js'],
+  accept: [
+    {
+      code: `div { overflow: auto; overscroll-behavior: contain; }`,
+      description: 'A container with shorthand overflow auto property.',
+    },
+    {
+      code: `div { overflow: hidden; }`,
+      description: 'A container with shorthand overflow hidden property.',
+    },
+    {
+      code: `div { overflow: scroll; overscroll-behavior: contain; }`,
+      description: 'A container with shorthand overflow scroll property.',
+    },
+    {
+      code: `div { overflow: auto hidden; overscroll-behavior: contain; }`,
+      description: 'A container with shorthand overflow auto hidden property.',
+    },
+    {
+      code: `div { overflow-x: hidden; }`,
+      description: 'A container with overflow-x hidden property.',
+    },
+    {
+      code: `div { overflow-x: auto; overscroll-behavior: contain; }`,
+      description: 'A container with overflow-x auto property.',
+    },
+    {
+      code: `div { overflow-x: auto; overflow-y: scroll; overscroll-behavior: contain; }`,
+      description:
+        'A container with overflow-x auto and overflow-y scroll property.',
+    },
+    {
+      code: `div { overflow-block: auto; overscroll-behavior: contain; }`,
+      description: 'A container with overflow-block auto property.',
+    },
+    {
+      code: `div { overflow-inline: hidden; }`,
+      description: 'A container with overflow-inline hidden property.',
+    },
+    {
+      code: `div { overflow-anchor: auto; }`,
+      description:
+        'A container with overflow-anchor property which should be ignored.',
+    },
+  ],
+
+  reject: [
+    {
+      code: `div { overflow: auto; }`,
+      description: 'A container with shorthand overflow auto property.',
+      message: messages.scrollChaining(),
+    },
+    {
+      code: `div { overflow: auto hidden; }`,
+      description: 'A container with shorthand overflow auto hidden property.',
+      message: messages.scrollChaining(),
+    },
+    {
+      code: `div { overflow-x: auto; }`,
+      description: 'A container with overflow-x auto property.',
+      message: messages.scrollChaining(),
+    },
+    {
+      code: `div { overflow-y: scroll; }`,
+      description: 'A container with overflow-y scroll property.',
+      message: messages.scrollChaining(),
+    },
+    {
+      code: `div { overflow-y: scroll; overflow-x: auto; }`,
+      description:
+        'A container with overflow-y scroll and overflow-x auto property.',
+      message: messages.scrollChaining(),
+    },
+    {
+      code: `div { overflow-block: scroll; overflow-inline: auto; }`,
+      description:
+        'A container with overflow-block scroll and overflow-inline auto property.',
+      message: messages.scrollChaining(),
+    },
+  ],
+});
+
+/* eslint-disable-next-line no-undef  */
+testRule({
+  ruleName,
   config: [true, { 'vendor-prefix-grouping': true }],
   plugins: ['./index.js'],
   accept: [


### PR DESCRIPTION
## 📒 Description

- adds a rule for enforcing [scroll chaining](https://defensivecss.dev/tip/scroll-chain/)

## 🚀 Changes

- adds new rule logic for enforcing scroll chaining
- adds tests for passing and failing examples
- updates docs with the new rule and examples

## 🔐 Closes

N/A

## ⛳️ Testing

- ran `npm run test` to ensure al tests pass