### PR TITLE
Remove Accidental Hover Logs and Undefined Includes

### DIFF
--- a/src/rules/use-defensive-css/index.js
+++ b/src/rules/use-defensive-css/index.js
@@ -33,13 +33,12 @@ let isLastStyleDeclaration = false;
 let isWrappedInHoverAtRule = false;
 
 function traverseParentRules(parent) {
-  console.log({ parent });
   if (parent.parent.type === 'root') {
     return;
   }
 
   if (parent.parent.type === 'atrule') {
-    if (parent.parent.params.includes('hover: hover')) {
+    if (parent.parent.params && parent.parent.params.includes('hover: hover')) {
       isWrappedInHoverAtRule = true;
     } else {
       traverseParentRules(parent.parent);
@@ -64,7 +63,7 @@ const ruleFunction = (_, options) => {
       if (options?.['accidental-hover']) {
         const parent = decl.parent;
         const selector = parent.selector;
-        const isHoverSelector = selector.includes(':hover');
+        const isHoverSelector = selector?.includes(':hover');
         isWrappedInHoverAtRule = false;
 
         if (isHoverSelector) {

--- a/src/rules/use-defensive-css/index.test.js
+++ b/src/rules/use-defensive-css/index.test.js
@@ -28,6 +28,11 @@ testRule({
       description:
         'Use nested media queries with hover in the middle for button hover state.',
     },
+    {
+      code: `@media all and (hover: hover) and (max-width: 699px) { .btn:hover { color: black; } }`,
+      description:
+        'Use nested media queries with hover in the middle for button hover state.',
+    },
   ],
 
   reject: [


### PR DESCRIPTION
## 📒 Description

- removes a sneaky console log
- adds checks before `.includes` methods

## 🚀 Changes

- removes a sneaky console log
- adds checks before `.includes` methods

## 🔐 Closes

#11 

## ⛳️ Testing

- ran `npm run test` and everything passes
