### PR TITLE
Fix False Positives with Flex Flow Shorthands

### DIFF
--- a/src/rules/use-defensive-css/index.js
+++ b/src/rules/use-defensive-css/index.js
@@ -154,11 +154,19 @@ const ruleFunction = (_, options) => {
           flexWrappingProps.nodeToReport = decl;
         }
 
+        if (decl.prop === 'flex-flow' && decl.value.includes('column')) {
+          flexWrappingProps.isFlexRow = false;
+          flexWrappingProps.isMissingFlexWrap = false;
+        }
+
         if (decl.prop === 'flex-direction' && decl.value.includes('column')) {
           flexWrappingProps.isFlexRow = false;
         }
 
-        if (decl.prop === 'flex-wrap') {
+        if (
+          decl.prop === 'flex-wrap' ||
+          (decl.prop === 'flex-flow' && decl.value.includes('wrap'))
+        ) {
           flexWrappingProps.isMissingFlexWrap = false;
         }
 

--- a/src/rules/use-defensive-css/index.test.js
+++ b/src/rules/use-defensive-css/index.test.js
@@ -209,6 +209,30 @@ testRule({
   plugins: ['./index.js'],
   accept: [
     {
+      code: `div { display: flex; flex-flow: column; }`,
+      description: 'A container with flex-flow: column defined.',
+    },
+    {
+      code: `div { display: flex; flex-flow: column-reverse wrap; }`,
+      description: 'A container with flex-flow: column wrap defined.',
+    },
+    {
+      code: `div { display: flex; flex-flow: row wrap; }`,
+      description: 'A container with flex-flow: row wrap defined.',
+    },
+    {
+      code: `div { display: flex; flex-flow: row-reverse wrap; }`,
+      description: 'A container with flex-flow: row-reverse wrap defined.',
+    },
+    {
+      code: `div { display: flex; flex-flow: row nowrap; }`,
+      description: 'A container with flex-flow: row nowrap defined.',
+    },
+    {
+      code: `div { display: flex; flex-flow: row-reverse nowrap; }`,
+      description: 'A container with flex-flow: row-reverse nowrap defined.',
+    },
+    {
       code: `div { display: flex; flex-wrap: nowrap; }`,
       description: 'A container with flex-wrap: wrap defined.',
     },
@@ -243,6 +267,16 @@ testRule({
   ],
 
   reject: [
+    {
+      code: `div { display: flex; flex-flow: row; }`,
+      description: 'A flex flow container without a wrap property defined.',
+      message: messages.flexWrapping(),
+    },
+    {
+      code: `div { display: flex; flex-flow: row-reverse; }`,
+      description: 'A flex flow container without a wrap property defined.',
+      message: messages.flexWrapping(),
+    },
     {
       code: `div { display: flex; }`,
       description: 'A flex container without a flex-wrap property defined.',


### PR DESCRIPTION
## 📒 Description

- add support for linting for flex-wrapping when using the shorthand `flex-flow` property.

## 🚀 Changes

- adds test coverage for flex-wrapping while using `flex-flow` shorthand
- supports warning when `flex-flow` properties are missing a wrapping value

## 🔐 Closes

#13 

## ⛳️ Testing

- adds test coverage for passing and failing examples of `flex-flow`
- ran `npm run test` to ensure al tests pass
