### PR TITLE
fix(accidental-hover): match shorthand media features

### DIFF
--- a/src/rules/use-defensive-css/index.js
+++ b/src/rules/use-defensive-css/index.js
@@ -38,7 +38,10 @@ function traverseParentRules(parent) {
   }
 
   if (parent.parent.type === 'atrule') {
-    if (parent.parent.params && parent.parent.params.includes('hover: hover')) {
+    if (
+      parent.parent.params &&
+      /\(hover(: hover)?\)/.test(parent.parent.params)
+    ) {
       isWrappedInHoverAtRule = true;
     } else {
       traverseParentRules(parent.parent);

--- a/src/rules/use-defensive-css/index.test.js
+++ b/src/rules/use-defensive-css/index.test.js
@@ -15,6 +15,10 @@ testRule({
       description: 'Use media query for button hover state.',
     },
     {
+      code: `@media (hover) { .btn:hover { color: black; } }`,
+      description: 'Use shorthand media query for button hover state.',
+    },
+    {
       code: `@media (min-width: 1px) { @media (hover: hover) { .btn:hover { color: black; } } }`,
       description: 'Use nested media queries for button hover state.',
     },


### PR DESCRIPTION
## 📒 Description

[Media Queries Level 4](https://drafts.csswg.org/mediaqueries-4/#mq-features) provides a shorthand syntax for boolean media features such as `(hover: hover)` - you can omit the feature value and write it simply as `(hover)`.

## 🚀 Changes

- Match shorthand media features

## 🔐 Closes

Nothing

## ⛳️ Testing

- Verified that tests pass with `npm run test`