### PR TITLE
Support Agnostic Formatting for Hover Media Queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-defensive-css",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A Stylelint plugin to enforce defensive CSS best practices.",
   "main": "src/index.js",
   "files": [

--- a/src/rules/use-defensive-css/index.js
+++ b/src/rules/use-defensive-css/index.js
@@ -38,10 +38,7 @@ function traverseParentRules(parent) {
   }
 
   if (parent.parent.type === 'atrule') {
-    if (
-      parent.parent.params &&
-      /\(hover(: hover)?\)/.test(parent.parent.params)
-    ) {
+    if (parent.parent.params && /hover(: hover)?/.test(parent.parent.params)) {
       isWrappedInHoverAtRule = true;
     } else {
       traverseParentRules(parent.parent);

--- a/src/rules/use-defensive-css/index.test.js
+++ b/src/rules/use-defensive-css/index.test.js
@@ -15,6 +15,10 @@ testRule({
       description: 'Use media query for button hover state.',
     },
     {
+      code: `@media ( hover: hover ) { .btn:hover { color: black; } }`,
+      description: 'Use media query for button hover state with spaces.',
+    },
+    {
       code: `@media (hover) { .btn:hover { color: black; } }`,
       description: 'Use shorthand media query for button hover state.',
     },


### PR DESCRIPTION
## 📒 Description

Removes the expected formatting of the hover media queries since this was opinionated and broke environments that did not follow this conventions.

## 🚀 Changes

- updates the regex used to check for a hover media query
- adds test with different hover media query formatting

## 🔐 Closes

#18 

## ⛳️ Testing

- wrote new test for this use case and verify everything passes
