### PR TITLE
Fix Accidental Hover False Positive Within :not() Selectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "stylelint-plugin-defensive-css",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "stylelint-plugin-defensive-css",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^18.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-defensive-css",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Stylelint plugin to enforce defensive CSS best practices.",
   "main": "src/index.js",
   "type": "module",

--- a/src/rules/use-defensive-css/index.js
+++ b/src/rules/use-defensive-css/index.js
@@ -76,6 +76,11 @@ const ruleFunction = (_, options) => {
         const isHoverSelector = selector?.includes(':hover');
         isWrappedInHoverAtRule = false;
 
+        // If the :hover selector is inside a :not() selector, ignore it
+        if (/:not\(([^)]*:hover[^)]*)\)/g.test(selector)) {
+          return;
+        }
+
         if (isHoverSelector) {
           traverseParentRules(parent);
 

--- a/src/rules/use-defensive-css/index.test.js
+++ b/src/rules/use-defensive-css/index.test.js
@@ -38,6 +38,14 @@ testRule({
       description:
         'Use nested media queries with hover in the middle for button hover state.',
     },
+    {
+      code: `div:not(:hover) { color: red; }`,
+      description: 'Use :hover selector inside of :not() selector.',
+    },
+    {
+      code: `div:not(:focus-visible, :hover) { color: red; }`,
+      description: 'Use :hover selector inside of a grouped :not() selector.',
+    },
   ],
 
   reject: [


### PR DESCRIPTION
## 📒 Description

- checks for `:hover` selectors inside of `:not()` selectors to prevent the accidental hover rule from reporting

## 🚀 Changes

- adds regexp check for `:not(:hover)` selectors
- adds tests for different `:not()` situations
- increments version to 1.0.1

## 🔐 Closes

#30 

## ⛳️ Testing

- ran `npm run test` to ensure all tests pass

<img width="307" alt="image" src="https://github.com/yuschick/stylelint-plugin-defensive-css/assets/563226/5acd162c-3cc2-4966-be0c-11d9f4515851">
