### PR TITLE
Fix False Hover Positive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-defensive-css",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A Stylelint plugin to enforce defensive CSS best practices.",
   "main": "src/index.js",
   "type": "module",

--- a/src/rules/use-defensive-css/index.js
+++ b/src/rules/use-defensive-css/index.js
@@ -47,12 +47,10 @@ function traverseParentRules(parent) {
     return;
   }
 
-  if (parent.parent.type === 'atrule') {
-    if (parent.parent.params && /hover(: hover)?/.test(parent.parent.params)) {
-      isWrappedInHoverAtRule = true;
-    } else {
-      traverseParentRules(parent.parent);
-    }
+  if (parent.parent.params && /hover(: hover)?/.test(parent.parent.params)) {
+    isWrappedInHoverAtRule = true;
+  } else {
+    traverseParentRules(parent.parent);
   }
 }
 

--- a/src/rules/use-defensive-css/index.test.js
+++ b/src/rules/use-defensive-css/index.test.js
@@ -46,6 +46,36 @@ testRule({
       code: `div:not(:focus-visible, :hover) { color: red; }`,
       description: 'Use :hover selector inside of a grouped :not() selector.',
     },
+    {
+      code: `web-component-name {
+	&:defined {
+		@media ( hover: hover ) {
+			details:not( [open] ) {
+				position: relative;
+				z-index: 1;
+
+				&::before {
+					content: '';
+					position: absolute;
+					top: 0;
+					left: 0;
+					z-index: -1;
+					width: 100%;
+					height: 100%;
+					background-color: #EFEFF0;
+					transition: opacity 0.2s;
+					opacity: 0;
+				}
+
+				&:hover::before {
+					opacity: 1;
+				}
+			}
+		}
+	}
+}`,
+      description: 'False positive complex example',
+    },
   ],
 
   reject: [


### PR DESCRIPTION
## 📒 Description

- fixes `atrule` check for deeply nested selectors
- increments package version number

## 🚀 Changes

- removes conditional `atrule` check
- increments package version to 1.0.4

## 🔐 Closes

- #36 

## ⛳️ Testing

- ran `npm run test` to ensure all tests pass
<img width="300" alt="image" src="https://github.com/yuschick/stylelint-plugin-defensive-css/assets/563226/5eb2d9cf-b0da-444a-a6e4-1829a03e153d">
