### PR TITLE
Enforce mask-repeat with background-repeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ div {
   background: url('some-image.jpg') black top center;
   background-repeat: no-repeat;
 }
+div {
+  mask: url('some-image.jpg') repeat top center;
+}
+div {
+  mask: url('some-image.jpg') top center;
+  mask-repeat: no-repeat;
+}
 ```
 
 #### ❌ Failing Examples
@@ -156,6 +163,12 @@ div {
 }
 div {
   background-image: url('some-image.jpg');
+}
+div {
+  mask: url('some-image.jpg') top center;
+}
+div {
+  mask-image: url('some-image.jpg');
 }
 ```
 

--- a/src/rules/use-defensive-css/base.js
+++ b/src/rules/use-defensive-css/base.js
@@ -9,6 +9,9 @@ export const ruleMessages = stylelint.utils.ruleMessages(ruleName, {
   backgroundRepeat() {
     return 'Whenever setting a background image, be sure to explicitly define a `background-repeat` value. Learn more: https://defensivecss.dev/tip/bg-repeat/';
   },
+  maskRepeat() {
+    return 'Whenever setting a mask image, be sure to explicitly define a `mask-repeat` value. Learn more: https://defensivecss.dev/tip/bg-repeat/';
+  },
   customPropertyFallbacks() {
     return 'Provide a fallback value for a custom property like `var(--your-custom-property, #000000)` to prevent issues in the event the custom property is not defined. Learn more: https://defensivecss.dev/tip/css-variable-fallback/';
   },

--- a/src/rules/use-defensive-css/index.js
+++ b/src/rules/use-defensive-css/index.js
@@ -10,6 +10,11 @@ const defaultBackgroundRepeatProps = {
   isMissingBackgroundRepeat: true,
   nodeToReport: undefined,
 };
+const defaultMaskRepeatProps = {
+  hasMaskImage: false,
+  isMissingMaskRepeat: true,
+  nodeToReport: undefined,
+};
 const defaultFlexWrappingProps = {
   isDisplayFlex: false,
   isFlexRow: true,
@@ -28,6 +33,7 @@ const defaultScrollChainingProps = {
 };
 
 let backgroundRepeatProps = { ...defaultBackgroundRepeatProps };
+let maskRepeatProps = { ...defaultMaskRepeatProps };
 let flexWrappingProps = { ...defaultFlexWrappingProps };
 let scrollbarGutterProps = { ...defaultScrollbarGutterProps };
 let scrollChainingProps = { ...defaultScrollChainingProps };
@@ -102,14 +108,28 @@ const ruleFunction = (_, options) => {
             !findShorthandBackgroundRepeat(decl.value);
           backgroundRepeatProps.nodeToReport = decl;
         }
+        if (decl.prop === 'mask' && hasUrl) {
+          maskRepeatProps.hasMaskImage = true;
+          maskRepeatProps.isMissingMaskRepeat = !findShorthandBackgroundRepeat(
+            decl.value,
+          );
+          maskRepeatProps.nodeToReport = decl;
+        }
 
         if (decl.prop === 'background-image' && hasUrl) {
           backgroundRepeatProps.hasBackgroundImage = true;
           backgroundRepeatProps.nodeToReport = decl;
         }
+        if (decl.prop === 'mask-image' && hasUrl) {
+          maskRepeatProps.hasMaskImage = true;
+          maskRepeatProps.nodeToReport = decl;
+        }
 
         if (decl.prop === 'background-repeat') {
           backgroundRepeatProps.isMissingBackgroundRepeat = false;
+        }
+        if (decl.prop === 'mask-repeat') {
+          maskRepeatProps.isMissingMaskRepeat = false;
         }
 
         if (isLastStyleDeclaration) {
@@ -121,8 +141,17 @@ const ruleFunction = (_, options) => {
               ruleName,
             });
           }
+          if (Object.values(maskRepeatProps).every((prop) => prop)) {
+            stylelint.utils.report({
+              message: ruleMessages.maskRepeat(),
+              node: maskRepeatProps.nodeToReport,
+              result,
+              ruleName,
+            });
+          }
 
           backgroundRepeatProps = { ...defaultBackgroundRepeatProps };
+          maskRepeatProps = { ...defaultMaskRepeatProps };
         }
       }
 

--- a/src/rules/use-defensive-css/index.js
+++ b/src/rules/use-defensive-css/index.js
@@ -95,14 +95,15 @@ const ruleFunction = (_, options) => {
 
       /* BACKGROUND REPEAT  */
       if (options?.['background-repeat']) {
-        if (decl.prop === 'background' && decl.value.includes('url(')) {
+        const hasUrl = decl.value.includes('url(');
+        if (decl.prop === 'background' && hasUrl) {
           backgroundRepeatProps.hasBackgroundImage = true;
           backgroundRepeatProps.isMissingBackgroundRepeat =
             !findShorthandBackgroundRepeat(decl.value);
           backgroundRepeatProps.nodeToReport = decl;
         }
 
-        if (decl.prop === 'background-image' && decl.value.includes('url(')) {
+        if (decl.prop === 'background-image' && hasUrl) {
           backgroundRepeatProps.hasBackgroundImage = true;
           backgroundRepeatProps.nodeToReport = decl;
         }

--- a/src/rules/use-defensive-css/index.test.js
+++ b/src/rules/use-defensive-css/index.test.js
@@ -146,6 +146,52 @@ testRule({
       description:
         'Using background-image with gradient and url with background-repeat property is okay.',
     },
+    {
+      code: `div { mask: url('some-image.jpg') repeat top center; }`,
+      description: "Shorthand mask property with 'repeat' value.",
+    },
+    {
+      code: `div { mask: url('some-image.jpg') repeat-x top center; }`,
+      description: "Shorthand mask property with 'repeat-x' value.",
+    },
+    {
+      code: `div { mask: url('some-image.jpg') repeat-y top center; }`,
+      description: "Shorthand mask property with 'repeat-y' value.",
+    },
+    {
+      code: `div { mask: url('some-image.jpg') no-repeat top center; }`,
+      description: "Shorthand mask property with 'no-repeat' value.",
+    },
+    {
+      code: `div { mask: url('some-image.jpg') round top center; }`,
+      description: "Shorthand mask property with 'round' value.",
+    },
+    {
+      code: `div { mask: url('some-image.jpg') space top center; }`,
+      description: "Shorthand mask property with 'space' value.",
+    },
+    {
+      code: `div { mask: url('some-image.jpg') space round top center; }`,
+      description: "Shorthand mask property with 'space round' value.",
+    },
+    {
+      code: `div { mask: url('some-image.jpg') black top center; mask-repeat: no-repeat; }`,
+      description: 'Shorthand mask property with mask-repeat property.',
+    },
+    {
+      code: `div { mask-image: url('some-image.jpg'); mask-repeat: no-repeat; }`,
+      description: 'Using mask-image with mask-repeat properties.',
+    },
+    {
+      code: `div { mask-image: linear-gradient(#e66465, #9198e5); }`,
+      description:
+        'Using a linear-gradient mask image without mask repeat is okay.',
+    },
+    {
+      code: `div { mask-image: linear-gradient(#e66465, #9198e5), url('some-image.jpg'); mask-repeat: no-repeat; }`,
+      description:
+        'Using mask-image with gradient and url with mask-repeat property is okay.',
+    },
   ],
 
   reject: [
@@ -165,6 +211,22 @@ testRule({
       description:
         'A background-image property with both a gradient and url() but no background-repeat property.',
       message: messages.backgroundRepeat(),
+    },
+    {
+      code: `div { mask: url('some-image.jpg') top center; }`,
+      description: 'A shorthand mask property without a repeat property.',
+      message: messages.maskRepeat(),
+    },
+    {
+      code: `div { mask-image: url('some-image.jpg'); }`,
+      description: 'A mask-image property without a mask-repeat property.',
+      message: messages.maskRepeat(),
+    },
+    {
+      code: `div { mask-image: linear-gradient(#e66465, #9198e5), url('some-image.jpg'); }`,
+      description:
+        'A mask-image property with both a gradient and url() but no mask-repeat property.',
+      message: messages.maskRepeat(),
     },
   ],
 });


### PR DESCRIPTION
## 📒 Description

The `mask` property suffers from [the same default `repeat` behaviour as `background`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-repeat#formal_definition), so this plugin should also help prevent the same issue there.

## 🚀 Changes

- Add support for `mask-*` properties to `background-repeat` rule.

## 🔐 Closes

_N/A_

## ⛳️ Testing

- Added tests to cover the new functionality.
- Ran `npm test` to ensure the new functionality works as intended.