### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request--checks.yaml
+++ b/.github/workflows/pull-request--checks.yaml
@@ -1,5 +1,8 @@
 name: Pull Request - Checks
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/yuschick/stylelint-plugin-defensive-css/security/code-scanning/1](https://github.com/yuschick/stylelint-plugin-defensive-css/security/code-scanning/1)

In general, the fix is to explicitly declare `permissions` for the `GITHUB_TOKEN` in the workflow, preferably at the workflow root so it applies to all jobs, and to grant only the minimal scopes needed. For a workflow that just checks out code, installs dependencies, and runs tests, read-only access to repository contents is sufficient.

The best fix here is to add a `permissions` block at the top level (alongside `name` and `on`) with `contents: read`. This documents that the workflow needs only read access to the repo contents and prevents accidental elevation if org/repo defaults are broader. Concretely, in `.github/workflows/pull-request--checks.yaml`, insert:

```yaml
permissions:
  contents: read
```

between the `name:` and `on:` blocks. No other changes, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
