### PR TITLE
fix: recognize nowrap in flex-flow shorthand

### DIFF
--- a/src/rules/require-flex-wrap/rule.test.ts
+++ b/src/rules/require-flex-wrap/rule.test.ts
@@ -54,6 +54,38 @@ testRule({
       description: 'flex-flow column-reverse (exempt)',
     },
     {
+      code: '.class { display: flex; flex-flow: row nowrap; }',
+      description: 'flex-flow with row and nowrap',
+    },
+    {
+      code: '.class { display: flex; flex-flow: nowrap; }',
+      description: 'flex-flow with nowrap shorthand',
+    },
+    {
+      code: '.class { display: flex; flex-flow: row-reverse nowrap; }',
+      description: 'flex-flow with row-reverse and nowrap',
+    },
+    {
+      code: '.class { display: flex; flex-flow: column nowrap; }',
+      description: 'flex-flow with column and nowrap (column exempt)',
+    },
+    {
+      code: `
+        @media (min-width: 768px) {
+          .class { display: flex; flex-flow: row nowrap; }
+        }
+      `,
+      description: 'flex-flow with nowrap inside media query',
+    },
+    {
+      code: `
+        @media (min-width: 768px) {
+          .class { display: flex; flex-wrap: nowrap; }
+        }
+      `,
+      description: 'flex-wrap nowrap inside media query',
+    },
+    {
       code: '.class { display: grid; }',
       description: 'grid display (not flex)',
     },

--- a/src/rules/require-flex-wrap/utils.ts
+++ b/src/rules/require-flex-wrap/utils.ts
@@ -7,5 +7,5 @@ export const isColumnDirection = (value: string): boolean => {
 };
 
 export const hasWrapValue = (value: string): boolean => {
-  return /\bwrap(-reverse)?\b/.test(value);
+  return /\b(no)?wrap(-reverse)?\b/.test(value);
 };


### PR DESCRIPTION
## 📒 Description

The `hasWrapValue` regex in `require-flex-wrap` fails to match `nowrap` inside `flex-flow` shorthand values like `flex-flow: row nowrap`, causing false positives.

## 🚀 Changes

- Fix regex in `hasWrapValue()` from `/\bwrap(-reverse)?\b/` to `/\b(no)?wrap(-reverse)?\b/`
- Add tests for `nowrap` in `flex-flow` shorthand and inside media queries

## 🔐 Closes

N/A.

## ⛳️ Testing

All tests pass.