### PR TITLE
Update test descriptions for vendor prefix rules

### DIFF
--- a/src/rules/no-mixed-vendor-prefixes/rule.test.ts
+++ b/src/rules/no-mixed-vendor-prefixes/rule.test.ts
@@ -26,7 +26,7 @@ testRule({
     },
     {
       code: `input::-ms-input-placeholder { color: #222; } input::-o-placeholder { color: #222; }`,
-      description: 'Split webkit and moz placeholder selectors to separate rules.',
+      description: 'Split ms and opera placeholder selectors to separate rules.',
     },
     {
       code: `div::before,div::after { color: #222; }`,
@@ -65,7 +65,7 @@ testRule({
     },
     {
       code: `input::-ms-input-placeholder, input::-o-placeholder { color: #222; }`,
-      description: 'Using webkit and moz placeholder selectors.',
+      description: 'Using ms and opera placeholder selectors.',
       message: messages.rejected('input::-ms-input-placeholder, input::-o-placeholder'),
     },
   ],


### PR DESCRIPTION
Found these two while scanning your codebase to learn how to do stylelint plugins ❤️

## 📒 Description

Fix two small typos in test file for no-mixed-vendor-prefixes.

## 🚀 Changes

2 typo fixes.

## 🔐 Closes

N/A

## ⛳️ Testing

Fixes the test descriptions of the very tests I updated.
