### PR TITLE
Fix: Support CSS Nesting with Require Pure Selectors Rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.9.2](https://github.com/yuschick/stylelint-plugin-defensive-css/compare/v2.9.1...v2.9.2) (2026-05-13)
+
+### Bug Fixes
+
+* support css nesting within require pure selector rule ([9a7d51e](https://github.com/yuschick/stylelint-plugin-defensive-css/commit/9a7d51e52d5bac5013bc4ae06839cbc6bc090a32))
+
 ## [2.9.1](https://github.com/yuschick/stylelint-plugin-defensive-css/compare/v2.9.0...v2.9.1) (2026-04-18)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stylelint-plugin-defensive-css",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint-plugin-defensive-css",
-      "version": "2.9.1",
+      "version": "2.9.2",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-defensive-css",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "A Stylelint plugin to enforce defensive CSS best practices.",
   "type": "module",
   "author": "Daniel Yuschick <daniel.yuschick@gmail.com>",

--- a/src/rules/require-pure-selectors/rule.test.ts
+++ b/src/rules/require-pure-selectors/rule.test.ts
@@ -14,12 +14,16 @@ testRule({
       description: 'chained class selectors',
     },
     {
+      code: `.button { color: red; &[aria-disabled="true"] { color: blue; } }`,
+      description: 'attribute selector nested within class selector',
+    },
+    {
       code: '#header { color: red; }',
       description: 'ID selector',
     },
     {
       code: '.button[disabled] { color: red; }',
-      description: 'classname with attribute selector ',
+      description: 'classname with attribute selector',
     },
     {
       code: '.card .button { color: red; }',
@@ -76,6 +80,26 @@ testRule({
     {
       code: '.item:not(.disabled) { color: red; }',
       description: 'not() with pure selector branch',
+    },
+    {
+      code: '.button { &.active { color: red; } }',
+      description: 'nesting modifier with class within pure parent',
+    },
+    {
+      code: '.card { &:hover { color: red; } }',
+      description: 'nesting pseudo-class within pure parent',
+    },
+    {
+      code: '.card { & button { color: red; } }',
+      description: 'nesting with element descendant within pure parent',
+    },
+    {
+      code: '#header { &.highlighted { color: red; } }',
+      description: 'nesting modifier with class within pure ID parent',
+    },
+    {
+      code: '.nav { & > .link { color: red; } }',
+      description: 'nesting with child combinator within pure parent',
     },
   ],
 
@@ -145,6 +169,21 @@ testRule({
       description: 'nested tag selector',
       message: messages.rejected('span'),
     },
+    {
+      code: 'button { &.active { color: red; } }',
+      description: 'impure element parent with nesting class modifier',
+      message: messages.rejected('button'),
+    },
+    {
+      code: 'div { &:hover { color: red; } }',
+      description: 'impure element parent with nesting pseudo-class',
+      message: messages.rejected('div'),
+    },
+    {
+      code: '.card { [hidden] { display: none; } }',
+      description: 'attribute selector nested without nesting reference',
+      message: messages.rejected('[hidden]'),
+    },
   ],
   /* eslint-enable sort-keys */
 });
@@ -157,6 +196,10 @@ testRule({
     {
       code: 'button[disabled] { color: red; }',
       description: 'button with attribute selector ',
+    },
+    {
+      code: `button { color: red; &[aria-disabled="true"] { color: blue; } }`,
+      description: 'attribute selector nested within an element selector',
     },
   ],
   reject: [

--- a/src/rules/require-pure-selectors/rule.ts
+++ b/src/rules/require-pure-selectors/rule.ts
@@ -8,6 +8,7 @@ import stylelint, { Rule } from 'stylelint';
 import { messages, meta, name } from './meta';
 import { severityOption, SeverityProps } from '../../utils/types';
 import { findImpureElement } from './utils';
+import { hasMatchingAncestor } from '../../utils/traversal';
 
 const { report, validateOptions } = stylelint.utils;
 
@@ -56,6 +57,25 @@ export const requirePureSelectors: Rule = (
       const impureNode = findImpureElement(selector, secondaryOptions);
 
       if (impureNode) {
+        const usesNestingSelector = /&/.test(selector);
+
+        if (usesNestingSelector) {
+          const isNestedInPureSelector = hasMatchingAncestor(
+            ruleNode,
+            (ancestor) =>
+              ancestor.type === 'rule' &&
+              !findImpureElement(ancestor.selector, secondaryOptions),
+          );
+
+          if (isNestedInPureSelector) return;
+        }
+
+        const hasNestedAttributeModifier =
+          secondaryOptions.ignoreAttributeModifiers &&
+          ruleNode.some((child) => child.type === 'rule' && /^&\[/.test(child.selector));
+
+        if (hasNestedAttributeModifier) return;
+
         report({
           message: messages.rejected(selector),
           node: ruleNode,

--- a/src/rules/require-pure-selectors/utils.ts
+++ b/src/rules/require-pure-selectors/utils.ts
@@ -61,8 +61,10 @@ export function findImpureElement(
             : allowAttributeModifiers
               ? // If attribute modifiers are allowed, check if the previous node exists to prevent global attribute selectors
                 !!prevNode?.type
-              : // if attribute modifiers are not allowed, only allow class and id selectors
-                prevNode?.type === 'class' || prevNode?.type === 'id';
+              : // if attribute modifiers are not allowed, only allow class, id, and nesting selectors
+                prevNode?.type === 'class' ||
+                prevNode?.type === 'id' ||
+                prevNode?.type === 'nesting';
 
           if (allowAttributeModifier) {
             return;


### PR DESCRIPTION
## 📒 Description

Updates the `require-pure-selectors` rule to test for and consider CSS nesting syntax.

## 🚀 Changes

- updates the `require-pure-selectors` rule to traverse parent selectors to detect potential pure selector nesting
- adds test coverage for various nested use cases

## 🔐 Closes

#198 

## ⛳️ Testing

<img width="794" height="287" alt="image" src="https://github.com/user-attachments/assets/0be42b98-2bab-41ca-aa52-6b855a4ac190" />
