### PR TITLE
fix: convert npm publish to attempt oicd publish

### DIFF
--- a/.github/workflows/release--official.yaml
+++ b/.github/workflows/release--official.yaml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -42,7 +46,6 @@ jobs:
       - name: Run official release
         run: npm run release:official
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Get version

--- a/.release-it--official.json
+++ b/.release-it--official.json
@@ -12,7 +12,8 @@
     "releaseName": "v${version}"
   },
   "npm": {
-    "publish": true
+    "publish": true,
+    "provenance": true
   },
   "hooks": {
     "after:bump": "npm run build"


### PR DESCRIPTION
## 📒 Description

updates release workflow to use npm oicd auth.

## 🚀 Changes

- updates release--official.yml with permissions and removes node token
- updates release-it--official file to include the provenance flag

## 🔐 Closes



## ⛳️ Testing
