### PR TITLE
fix: require pure selectors and keyframes false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.9.3](https://github.com/yuschick/stylelint-plugin-defensive-css/compare/v2.9.2...v2.9.3) (2026-05-22)
+
+### Bug Fixes
+
+* convert npm publish to attempt oicd publish ([#200](https://github.com/yuschick/stylelint-plugin-defensive-css/issues/200)) ([acd316b](https://github.com/yuschick/stylelint-plugin-defensive-css/commit/acd316b3dfc4983b0cc9aa5dfc632510bf2241ef))
+* require pure selectors and keyframes false positives ([f63b3a9](https://github.com/yuschick/stylelint-plugin-defensive-css/commit/f63b3a92f9a82ddf94f3df091e6f0f4b74dfe1ce))
+
 ## [2.9.2](https://github.com/yuschick/stylelint-plugin-defensive-css/compare/v2.9.1...v2.9.2) (2026-05-13)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stylelint-plugin-defensive-css",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint-plugin-defensive-css",
-      "version": "2.9.2",
+      "version": "2.9.3",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-defensive-css",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "A Stylelint plugin to enforce defensive CSS best practices.",
   "type": "module",
   "author": "Daniel Yuschick <daniel.yuschick@gmail.com>",

--- a/src/rules/require-pure-selectors/rule.test.ts
+++ b/src/rules/require-pure-selectors/rule.test.ts
@@ -86,6 +86,10 @@ testRule({
       description: 'nesting modifier with class within pure parent',
     },
     {
+      code: ".button { &:not([aria-disabled='true'], [aria-busy='true']):hover { --button-color-surface: var(--button-color-surface-hover); } }",
+      description: 'nested :not() with attribute selectors inside pure parent',
+    },
+    {
       code: '.card { &:hover { color: red; } }',
       description: 'nesting pseudo-class within pure parent',
     },
@@ -100,6 +104,14 @@ testRule({
     {
       code: '.nav { & > .link { color: red; } }',
       description: 'nesting with child combinator within pure parent',
+    },
+    {
+      code: '@keyframes { to { color: red; } }',
+      description: 'keyframes rule with to',
+    },
+    {
+      code: '@keyframes { 100% { color: red; } }',
+      description: 'keyframes rule with percentage',
     },
   ],
 

--- a/src/rules/require-pure-selectors/rule.ts
+++ b/src/rules/require-pure-selectors/rule.ts
@@ -59,22 +59,29 @@ export const requirePureSelectors: Rule = (
       if (impureNode) {
         const usesNestingSelector = /&/.test(selector);
 
-        if (usesNestingSelector) {
-          const isNestedInPureSelector = hasMatchingAncestor(
-            ruleNode,
-            (ancestor) =>
-              ancestor.type === 'rule' &&
-              !findImpureElement(ancestor.selector, secondaryOptions),
-          );
+        const shouldSkip = hasMatchingAncestor(ruleNode, (ancestor) => {
+          if (ancestor.type === 'atrule' && ancestor.name === 'keyframes') {
+            return true;
+          }
 
-          if (isNestedInPureSelector) return;
+          return (
+            usesNestingSelector &&
+            ancestor.type === 'rule' &&
+            !findImpureElement(ancestor.selector, secondaryOptions)
+          );
+        });
+
+        if (shouldSkip) {
+          return;
         }
 
         const hasNestedAttributeModifier =
           secondaryOptions.ignoreAttributeModifiers &&
           ruleNode.some((child) => child.type === 'rule' && /^&\[/.test(child.selector));
 
-        if (hasNestedAttributeModifier) return;
+        if (hasNestedAttributeModifier) {
+          return;
+        }
 
         report({
           message: messages.rejected(selector),


### PR DESCRIPTION
## 📒 Description

Updates the `require-pure-selectors` rule from incorrectly flagging values within a `@keyframes` declaration.

## 🚀 Changes

- updates the `require-pure-selectors` rule logic to skip `@keyframes` declarations
- adds test coverage for "to" and "100%" checks

## 🔐 Closes



## ⛳️ Testing

- rand `npm run test` to verify all tests pass