### PR TITLE
fix: skip system font fallback check for pure var() values

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,9 +715,9 @@ This rule enforces that the ratio between the min and max values in a `clamp()` 
 
 #### No Unsafe Clamp Font Size Options
 
-| Option               | Type                                  | Default | Description                                                                                                  |
-| -------------------- | ------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------ |
-| `maxRatio`           | `number`                              | `2.5`   | The maximum allowed ratio between clamp max and min values.                                                  |
+| Option               | Type                                  | Default | Description                                                                                                                                               |
+| -------------------- | ------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `maxRatio`           | `number`                              | `2.5`   | The maximum allowed ratio between clamp max and min values.                                                                                               |
 | `reportUnresolvable` | `boolean \| [boolean, SeverityProps]` | `true`  | Report when the min/max ratio cannot be determined due to mixed units. `var()` functions are given the benefit of the doubt. Can specify custom severity. |
 
 ```json
@@ -2078,6 +2078,8 @@ Custom or non-standard fonts can fail to load due to network issues, font licens
 > **CSS system font generics** (e.g., `sans-serif`, `serif`, `monospace`, `system-ui`) are resolved by the browser itself and are accepted in **both loose and strict modes**.
 >
 > CSS global keywords (`inherit`, `initial`, `unset`, `revert`, `revert-layer`) are always accepted since they delegate font resolution to the cascade.
+>
+> Values composed entirely of `var()` references (e.g. `font: var(--font-m)` or `font-family: var(--a), var(--b)`) are skipped, since the plugin does not resolve custom properties and the fallback may be defined within the variable. Use the `ignore` option for partial values such as `font: 1.2em var(--font-family)`.
 
 ```ts
 interface SecondaryOptions {
@@ -2161,6 +2163,11 @@ interface SecondaryOptions {
 /* CSS global keywords are always accepted */
 .heading {
   font-family: inherit;
+}
+
+/* Values made up entirely of var() references are skipped */
+.title {
+  font: var(--font-m);
 }
 ```
 

--- a/src/rules/require-system-font-fallback/rule.test.ts
+++ b/src/rules/require-system-font-fallback/rule.test.ts
@@ -150,6 +150,22 @@ testRule({
       code: '.heading { font: inherit; }',
       description: 'font shorthand with CSS global keyword inherit',
     },
+    {
+      code: '.heading { font-family: var(--font-family); }',
+      description: 'font-family composed entirely of a single var() reference',
+    },
+    {
+      code: '.title { font: var(--font-m); }',
+      description: 'font shorthand composed entirely of a single var() reference',
+    },
+    {
+      code: '.heading { font-family: var(--font-primary), var(--font-secondary); }',
+      description: 'font-family composed entirely of multiple var() references',
+    },
+    {
+      code: '.heading { font-family: var(--font-family, sans-serif); }',
+      description: 'font-family var() reference with a nested fallback value',
+    },
   ],
 
   reject: [
@@ -194,9 +210,15 @@ testRule({
       message: messages.looseReject('"Custom Font", Sans-Serif'),
     },
     {
-      code: '.heading { font-family: var(--font-family); }',
-      description: 'font-family with CSS variable and no ignore pattern',
-      message: messages.looseReject('var(--font-family)'),
+      code: '.heading { font-family: "Custom Font", var(--fallback); }',
+      description:
+        'font-family with a custom font and a var() not composed entirely of var()',
+      message: messages.looseReject('"Custom Font", var(--fallback)'),
+    },
+    {
+      code: '.heading { font: 1.2em var(--font-family); }',
+      description: 'font shorthand with size and a var() not composed entirely of var()',
+      message: messages.looseReject('1.2em var(--font-family)'),
     },
     {
       code: '.heading { font: bold "Custom Font"; }',
@@ -278,6 +300,10 @@ testRule({
     {
       code: '.heading { font-family: revert-layer; }',
       description: 'font-family with CSS global keyword revert-layer',
+    },
+    {
+      code: '.title { font: var(--font-m); }',
+      description: 'font shorthand composed entirely of a single var() reference',
     },
   ],
 

--- a/src/rules/require-system-font-fallback/rule.ts
+++ b/src/rules/require-system-font-fallback/rule.ts
@@ -6,7 +6,7 @@
 
 import stylelint, { Rule } from 'stylelint';
 import { messages, meta, name } from './meta';
-import { cssSystemFonts, webSafeFonts } from './utils';
+import { cssSystemFonts, isOnlyVarReferences, webSafeFonts } from './utils';
 import { severityOption, SeverityProps } from '../../utils/types';
 import { matchesIgnorePattern } from '../../utils/ignore';
 import { globalKeywords } from '../../utils/css';
@@ -61,6 +61,10 @@ export const requireSystemFontFallback: Rule = (
       }
 
       if (globalKeywords.includes(decl.value.trim())) {
+        return;
+      }
+
+      if (isOnlyVarReferences(decl.value)) {
         return;
       }
 

--- a/src/rules/require-system-font-fallback/utils.ts
+++ b/src/rules/require-system-font-fallback/utils.ts
@@ -11,6 +11,57 @@ export const webSafeFonts = new Set([
   'Verdana',
 ]);
 
+const VAR_FUNCTION_START = 'var(';
+
+/**
+ * Determines whether a declaration value is composed entirely of `var(...)`
+ * references (optionally separated by commas). Since the plugin does not
+ * resolve custom properties, such values cannot be validated and should be
+ * skipped instead of reported as missing a fallback.
+ */
+export function isOnlyVarReferences(value: string): boolean {
+  const lower = value.toLowerCase();
+  let remainder = '';
+  let index = 0;
+
+  while (index < value.length) {
+    const isVarStart =
+      lower.startsWith(VAR_FUNCTION_START, index) &&
+      !/[a-z0-9-]/i.test(value[index - 1] ?? '');
+
+    if (isVarStart) {
+      let depth = 0;
+      let cursor = index + VAR_FUNCTION_START.length - 1; // points at the '('
+      let isClosed = false;
+
+      for (; cursor < value.length; cursor++) {
+        if (value[cursor] === '(') {
+          depth++;
+        } else if (value[cursor] === ')') {
+          depth--;
+          if (depth === 0) {
+            cursor++;
+            isClosed = true;
+            break;
+          }
+        }
+      }
+
+      if (!isClosed) {
+        return false;
+      }
+
+      index = cursor;
+      continue;
+    }
+
+    remainder += value[index];
+    index++;
+  }
+
+  return value.trim().length > 0 && /^[\s,]*$/.test(remainder);
+}
+
 export const cssSystemFonts = new Set([
   '-moz-button',
   '-moz-desktop',


### PR DESCRIPTION
## 📒 Description

`require-system-font-fallback` no longer flags `font` / `font-family` values composed entirely of `var()` references, since the plugin doesn't resolve custom properties and the fallback may live inside the variable.

## 🚀 Changes

- skip declarations whose value is only `var()` references (incl. multiple/nested vars)
- partial values like `font: 1.2em var(--x)` still require the `ignore` option
- update tests and README

## 🔐 Closes

Closes #205

## ⛳️ Testing

- `npm test`
- `npm run lint`