### PR TITLE
Fix: Ignore Custom Properties in Font Fallback Rule

### DIFF
--- a/src/rules/no-fixed-sizes/utils.ts
+++ b/src/rules/no-fixed-sizes/utils.ts
@@ -1,3 +1,5 @@
+import { checkForCustomProperty } from '../../utils/css';
+
 const PX_VALUE = /\d+(\.\d+)?px\b/i;
 
 const VALIDATED_FUNCTIONS = [
@@ -59,8 +61,7 @@ export const isValidValue = (value: string): boolean => {
   const functionPattern = new RegExp(`\\b(${VALIDATED_FUNCTIONS.join('|')})\\s*\\(`, 'i');
 
   if (functionPattern.test(normalized)) {
-    // If the function contains var(), it's 'flexible-ish' (we don't know the value)
-    if (/var\(/.test(normalized)) {
+    if (checkForCustomProperty(normalized)[0]) {
       return true;
     }
 

--- a/src/rules/no-unsafe-clamp-font-size/rule.ts
+++ b/src/rules/no-unsafe-clamp-font-size/rule.ts
@@ -9,6 +9,7 @@ import { messages, meta, name } from './meta';
 import { severityOption, SeverityProps } from '../../utils/types';
 import { parseClampArguments } from './utils';
 import { validateBasicOption } from '../../utils/validation';
+import { checkForCustomProperty } from '../../utils/css';
 
 const { report, validateOptions } = stylelint.utils;
 
@@ -80,7 +81,7 @@ export const noUnsafeClampFontSize: Rule = (
       /**
        * 3. Check if min or max contains var() — if so, skip entirely.
        */
-      if (min.includes('var(') || max.includes('var(')) {
+      if (checkForCustomProperty(min)[0] || checkForCustomProperty(max)[0]) {
         return;
       }
 

--- a/src/rules/require-system-font-fallback/rule.test.ts
+++ b/src/rules/require-system-font-fallback/rule.test.ts
@@ -150,6 +150,31 @@ testRule({
       code: '.heading { font: inherit; }',
       description: 'font shorthand with CSS global keyword inherit',
     },
+    {
+      code: '.heading { font-family: var(--font-family); }',
+      description: 'font-family composed entirely of a single var() reference',
+    },
+    {
+      code: '.title { font: var(--font-m); }',
+      description: 'font shorthand composed entirely of a single var() reference',
+    },
+    {
+      code: '.heading { font-family: var(--font-primary), var(--font-secondary); }',
+      description: 'font-family composed entirely of multiple var() references',
+    },
+    {
+      code: '.heading { font-family: var(--font-family, sans-serif); }',
+      description: 'font-family var() reference with a nested fallback value',
+    },
+    {
+      code: '.heading { font-family: "Custom Font", var(--fallback); }',
+      description:
+        'font-family with a custom font and a var() not composed entirely of var()',
+    },
+    {
+      code: '.heading { font: 1.2em var(--font-family); }',
+      description: 'font shorthand with size and a var() not composed entirely of var()',
+    },
   ],
 
   reject: [
@@ -192,11 +217,6 @@ testRule({
       code: '.heading { font-family: "Custom Font", Sans-Serif; }',
       description: 'font-family with incorrect casing on generic family',
       message: messages.looseReject('"Custom Font", Sans-Serif'),
-    },
-    {
-      code: '.heading { font-family: var(--font-family); }',
-      description: 'font-family with CSS variable and no ignore pattern',
-      message: messages.looseReject('var(--font-family)'),
     },
     {
       code: '.heading { font: bold "Custom Font"; }',

--- a/src/rules/require-system-font-fallback/rule.ts
+++ b/src/rules/require-system-font-fallback/rule.ts
@@ -9,7 +9,7 @@ import { messages, meta, name } from './meta';
 import { cssSystemFonts, webSafeFonts } from './utils';
 import { severityOption, SeverityProps } from '../../utils/types';
 import { matchesIgnorePattern } from '../../utils/ignore';
-import { globalKeywords } from '../../utils/css';
+import { checkForCustomProperty, globalKeywords } from '../../utils/css';
 import { hasMatchingAncestor } from '../../utils/traversal';
 
 const { report, validateOptions } = stylelint.utils;
@@ -71,6 +71,10 @@ export const requireSystemFontFallback: Rule = (
       let hasWebSafeFallback = false;
 
       for (const value of values) {
+        if (checkForCustomProperty(value)[0]) {
+          return;
+        }
+
         for (const val of value.split(',')) {
           if (matchesIgnorePattern(val, ignore)) {
             return;

--- a/src/utils/css.ts
+++ b/src/utils/css.ts
@@ -1,1 +1,8 @@
 export const globalKeywords = ['inherit', 'initial', 'unset', 'revert', 'revert-layer'];
+
+export function checkForCustomProperty(value: string): [boolean, string[]] {
+  const normalized = value.toLocaleLowerCase().trim();
+  const fallbacks = normalized.split(',').slice(1);
+
+  return [/var\(/.test(normalized), fallbacks];
+}


### PR DESCRIPTION
## 📒 Description

This change makes the `require-system-font-fallback` rule return early when it detects a custom property in the value. This behavior is intentionally shallow, as aligns with other rules that do similar early returns on custom properties instead of attempting to resolve N layers.

## 🚀 Changes

- updates the `require-system-font-fallback` rule to return early when it detects a custom property value
- updates the rule's test coverage to reflect these changes
- adds the `checkForCustomProperty()` common util function
  - uses the `checkForCustomProperty()` function throughout

## 🔐 Closes

#205 

## ⛳️ Testing

- ran `npm run test` to verify that all tests pass
- ran `npm run build` to verify all builds pass