### PR TITLE
Add Require Grid MinMax Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 ![Stylelint Plugin - Defensive CSS Logo](./assets/logo--light.webp#gh-light-mode-only)
 
 ![Stylelint Plugin Defensive CSS License](https://img.shields.io/github/license/yuschick/stylelint-plugin-defensive-css?style=for-the-badge)
-![Stylelint PLugin Defensive CSS Latest NPM Version](https://img.shields.io/npm/v/stylelint-plugin-defensive-css?style=for-the-badge)
-![Stylelint PLugin Defensive CSS Main Workflow Status](https://img.shields.io/github/actions/workflow/status/yuschick/stylelint-plugin-defensive-css/pull-request--checks.yaml?style=for-the-badge)
-![Stylelint PLugin Defensive CSS NPM Downloads](https://img.shields.io/npm/dw/stylelint-plugin-defensive-css?style=for-the-badge)
+![Stylelint Plugin Defensive CSS Latest NPM Version](https://img.shields.io/npm/v/stylelint-plugin-defensive-css?style=for-the-badge)
+![Stylelint Plugin Defensive CSS Main Workflow Status](https://img.shields.io/github/actions/workflow/status/yuschick/stylelint-plugin-defensive-css/pull-request--checks.yaml?style=for-the-badge)
+![Stylelint Plugin Defensive CSS NPM Downloads](https://img.shields.io/npm/dw/stylelint-plugin-defensive-css?style=for-the-badge)
 
 A Stylelint plugin to help you write more defensive, accessible, and maintainable CSS. Catch layout and accessibility bugs before they ship, enforce team-wide best practices, and guard against the subtle CSS pitfalls that break real-world experiences.
 
@@ -166,12 +166,13 @@ The plugin provides multiple rules that can be toggled on and off as needed.
 12. [Require Flex Wrap](#require-flex-wrap)
 13. [Require Focus Visible](#require-focus-visible)
 14. [Require Forced Colors Focus](#require-forced-colors-focus)
-15. [Require Named Grid Lines](#require-named-grid-lines)
-16. [Require Overscroll Behavior](#require-overscroll-behavior)
-17. [Require Prefers Reduced Motion](#require-prefers-reduced-motion)
-18. [Require Pure Selectors](#require-pure-selectors)
-19. [Require Scrollbar Gutter](#require-scrollbar-gutter)
-20. [Require System Font Fallback](#require-system-font-fallback)
+15. [Require Grid Minmax](#require-grid-minmax)
+16. [Require Named Grid Lines](#require-named-grid-lines)
+17. [Require Overscroll Behavior](#require-overscroll-behavior)
+18. [Require Prefers Reduced Motion](#require-prefers-reduced-motion)
+19. [Require Pure Selectors](#require-pure-selectors)
+20. [Require Scrollbar Gutter](#require-scrollbar-gutter)
+21. [Require System Font Fallback](#require-system-font-fallback)
 
 ---
 
@@ -1481,9 +1482,108 @@ The rule gives the benefit of the doubt to `var()`, `inherit`, `revert`, and oth
 
 ---
 
-### Require Named Grid Lines
+### Require Grid Minmax
 
-Unnamed grid lines make layouts harder to understand and maintain. Numeric positions like `grid-column: 1 / 3` are ambiguous and prone to errors when the grid structure changes. Named lines like `[sidebar-start]` provide clarity and self-documenting code.
+A grid column defined with a raw `1fr` will size to its content's intrinsic minimum, meaning a long word, a wide image, or an unbreakable string can force the track — and the entire grid — to overflow its container. Wrapping the value in `minmax(0, 1fr)` overrides that automatic minimum, allowing the track to shrink and preventing content blowouts.
+
+**Enable this rule to:** Flag raw `1fr` values on `grid-template-columns` and `grid-auto-columns` and automatically fix them to `minmax(0, 1fr)`.
+
+> [!NOTE]
+> This rule only checks the `grid-template-columns` and `grid-auto-columns` properties. It does not lint the `grid`, `grid-template`, or other grid shorthand properties, where reliably isolating the column tracks from row tracks, area strings, and `auto-flow` keywords is ambiguous.
+
+```json
+{
+  "rules": {
+    "defensive-css/require-grid-minmax": true
+  }
+}
+```
+
+#### Require Grid Minmax Options
+
+> [!TIP]
+> This rule is fixable by passing the `{ fix: true }` option.
+
+A `1fr` value already wrapped in `minmax()` or `fit-content()` is considered safe and is left untouched, even when it appears alongside a raw `1fr` in the same declaration.
+
+**Configuration:** By default, this rule checks all selectors. Use the `ignore` option to exclude specific selectors by exact string or regular expression. Nested declarations are skipped when any ancestor selector matches an ignore pattern.
+
+```ts
+interface SecondaryOptions {
+  ignore?: (string | RegExp)[];
+}
+```
+
+```json
+{
+  "rules": {
+    "defensive-css/require-grid-minmax": [true, {
+        "fix": true,
+        "ignore": [".legacy-layout", /^\.grid-/],
+        "severity": "warning"
+    }]
+  }
+}
+```
+
+#### Require Grid Minmax Examples
+
+<details>
+<summary>✅ Passing Examples</summary>
+
+```css
+div {
+  grid-template-columns: minmax(0, 1fr) 250px;
+}
+
+div {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+div {
+  grid-auto-columns: minmax(0, 1fr);
+}
+
+/* fr units on non-column properties are not checked */
+div {
+  grid-template-rows: 1fr 250px;
+}
+
+/* the grid shorthand is not checked */
+div {
+  grid: 1fr / 1fr;
+}
+```
+
+</details>
+
+<details>
+<summary>❌ Failing Examples</summary>
+
+```css
+div {
+  grid-template-columns: 1fr 250px;
+}
+
+div {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+div {
+  grid-auto-columns: 1fr;
+}
+
+/* the raw 1fr is flagged even alongside a protected minmax() */
+div {
+  grid-template-columns: minmax(0, 1fr) 1fr;
+}
+```
+
+</details>
+
+---
+
+### Require Named Grid Lines
 
 **Enable this rule to:** Require all grid tracks to be associated with named lines using the `[name]` syntax in `grid-template-columns`, `grid-template-rows`, and the `grid` shorthand.
 

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -15,6 +15,7 @@ export default {
     'defensive-css/require-flex-wrap': [true, { severity: 'error' }],
     'defensive-css/require-focus-visible': [true, { severity: 'error' }],
     'defensive-css/require-forced-colors-focus': [true, { severity: 'error' }],
+    'defensive-css/require-grid-minmax': [true, { fix: true, severity: 'error' }],
     'defensive-css/require-named-grid-lines': [
       true,
       { columns: [true, { severity: 'error' }], rows: [true, { severity: 'warning' }] },

--- a/src/configs/strict.ts
+++ b/src/configs/strict.ts
@@ -24,6 +24,7 @@ export default {
     'defensive-css/require-flex-wrap': [true, { severity: 'error' }],
     'defensive-css/require-focus-visible': [true, { severity: 'error' }],
     'defensive-css/require-forced-colors-focus': [true, { severity: 'error' }],
+    'defensive-css/require-grid-minmax': [true, { fix: true, severity: 'error' }],
     'defensive-css/require-named-grid-lines': [true, { severity: 'error' }],
     'defensive-css/require-overscroll-behavior': [true, { severity: 'error' }],
     'defensive-css/require-prefers-reduced-motion': [true, { severity: 'error' }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import requireDynamicViewportHeight from './rules/require-dynamic-viewport-heigh
 import requireFlexWrap from './rules/require-flex-wrap';
 import requireFocusVisible from './rules/require-focus-visible';
 import requireForcedColorsFocus from './rules/require-forced-colors-focus';
+import requireGridMinmax from './rules/require-grid-minmax';
 import requireNamedGridLines from './rules/require-named-grid-lines';
 import requirePrefersReducedMotion from './rules/require-prefers-reduced-motion';
 import requireOverscrollBehavior from './rules/require-overscroll-behavior';
@@ -34,6 +35,7 @@ export default [
   requireFlexWrap,
   requireFocusVisible,
   requireForcedColorsFocus,
+  requireGridMinmax,
   requireNamedGridLines,
   requirePrefersReducedMotion,
   requireOverscrollBehavior,

--- a/src/rules/require-grid-minmax/index.ts
+++ b/src/rules/require-grid-minmax/index.ts
@@ -1,0 +1,5 @@
+import stylelint from 'stylelint';
+import * as meta from './meta';
+import { requireGridMinmax } from './rule';
+
+export default stylelint.createPlugin(meta.name, requireGridMinmax);

--- a/src/rules/require-grid-minmax/meta.ts
+++ b/src/rules/require-grid-minmax/meta.ts
@@ -1,0 +1,16 @@
+import stylelint, { RuleMeta } from 'stylelint';
+
+const { ruleMessages } = stylelint.utils;
+
+export const name = 'defensive-css/require-grid-minmax';
+
+export const messages = ruleMessages(name, {
+  rejected: () =>
+    `Unexpected column size of "1fr". To prevent potential grid content blowouts, use "minmax(0, 1fr)" instead.`,
+});
+
+export const meta: RuleMeta = {
+  deprecated: false,
+  fixable: true,
+  url: 'https://github.com/yuschick/stylelint-plugin-defensive-css',
+};

--- a/src/rules/require-grid-minmax/rule.test.ts
+++ b/src/rules/require-grid-minmax/rule.test.ts
@@ -1,0 +1,310 @@
+import { messages, name } from './meta';
+
+/* Test the default configuration */
+testRule({
+  config: [true],
+  ruleName: name,
+  /* eslint-disable sort-keys */
+  accept: [
+    {
+      code: '.class { display: grid; grid-template-columns: minmax(0, 1fr) 250px; }',
+      description: 'grid-template-columns with minmax(0, 1fr) is acceptable',
+    },
+    {
+      code: '.class { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); }',
+      description:
+        'grid-template-columns with repeat() wrapping minmax(0, 1fr) is acceptable',
+    },
+    {
+      code: '.class { grid-template-columns: minmax(100px, 1fr); }',
+      description: 'grid-template-columns with a non-zero minmax() minimum is acceptable',
+    },
+    {
+      code: '.class { grid-template-columns: fit-content(1fr); }',
+      description: 'grid-template-columns with 1fr inside fit-content() is acceptable',
+    },
+    {
+      code: '.class { grid-template-columns: 250px 500px auto; }',
+      description: 'grid-template-columns without any 1fr value is acceptable',
+    },
+    {
+      code: '.class { grid-template-columns: repeat(3, 100px); }',
+      description: 'grid-template-columns with fixed repeat() sizes is acceptable',
+    },
+    {
+      code: '.class { grid-template-columns: repeat(3, minmax(0, 1fr)); }',
+      description:
+        'grid-template-columns with repeat() count wrapping minmax() is acceptable',
+    },
+    {
+      code: '.class { grid-template-columns: repeat(auto-fit, minmax(0, 1fr)); }',
+      description:
+        'grid-template-columns with auto-fit repeat() wrapping minmax() is acceptable',
+    },
+    {
+      code: '.class { grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); }',
+      description:
+        'grid-template-columns with auto-fill repeat() wrapping minmax() is acceptable',
+    },
+    {
+      code: '.class { grid-template-columns: minmax(0, 1fr) minmax(100px, 1fr); }',
+      description:
+        'grid-template-columns with multiple protected minmax() values is acceptable',
+    },
+    {
+      code: '.class { grid-template-columns: fit-content(200px) minmax(0, 1fr); }',
+      description:
+        'grid-template-columns mixing fit-content() and minmax() is acceptable',
+    },
+    {
+      code: '.class { grid-template-columns: 2fr 3fr; }',
+      description: 'grid-template-columns with only non-1fr fr units is not flagged',
+    },
+    {
+      code: '.class { grid-auto-columns: minmax(0, 1fr); }',
+      description: 'grid-auto-columns with minmax(0, 1fr) is acceptable',
+    },
+    {
+      code: '.class { grid-auto-columns: repeat(auto-fit, minmax(0, 1fr)); }',
+      description:
+        'grid-auto-columns with auto-fit repeat() wrapping minmax() is acceptable',
+    },
+    {
+      code: '.class { grid-auto-columns: 100px; }',
+      description: 'grid-auto-columns without any 1fr value is acceptable',
+    },
+    {
+      code: '.class { grid-template-rows: 1fr 250px; }',
+      description: 'grid-template-rows is not checked by this rule',
+    },
+    {
+      code: '.class { grid-auto-rows: 1fr; }',
+      description: 'grid-auto-rows is not checked by this rule',
+    },
+    {
+      code: '.class { grid: 1fr / 1fr; }',
+      description: 'grid shorthand is not checked by this rule',
+    },
+    {
+      code: '.class { flex: 1 1 0; }',
+      description: 'unrelated declarations are ignored',
+    },
+  ],
+  reject: [
+    {
+      code: '.class { display: grid; grid-template-columns: 1fr 250px; }',
+      description: 'grid-template-columns with a single raw 1fr is rejected',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: 1fr; }',
+      description: 'grid-template-columns with only a raw 1fr is rejected',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: 1fr 1fr 1fr; }',
+      description: 'grid-template-columns with multiple raw 1fr values is rejected once',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: 250px 1fr 2fr; }',
+      description:
+        'grid-template-columns mixing fixed, raw 1fr, and other fr units is rejected',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: repeat(3, 1fr); }',
+      description: 'grid-template-columns with a raw 1fr inside repeat() is rejected',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: minmax(0, 1fr) 1fr; }',
+      description:
+        'grid-template-columns with a raw 1fr alongside a protected minmax() is rejected',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: fit-content(1fr) 1fr; }',
+      description:
+        'grid-template-columns with a raw 1fr alongside a protected fit-content() is rejected',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: repeat(auto-fit, 1fr); }',
+      description:
+        'grid-template-columns with a raw 1fr inside an auto-fit repeat() is rejected',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: repeat(auto-fill, 1fr); }',
+      description:
+        'grid-template-columns with a raw 1fr inside an auto-fill repeat() is rejected',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: repeat(2,1fr); }',
+      description:
+        'grid-template-columns with a raw 1fr inside repeat() with no spacing is rejected',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: repeat(2, minmax(0, 1fr)) 1fr; }',
+      description:
+        'grid-template-columns with a raw 1fr after a protected repeat() is rejected',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: minmax(0, 1fr) minmax(100px, 1fr) 1fr; }',
+      description:
+        'grid-template-columns with a raw 1fr among multiple protected minmax() values is rejected',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-auto-columns: 1fr; }',
+      description: 'grid-auto-columns with a raw 1fr is rejected',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-auto-columns: 1fr 1fr; }',
+      description: 'grid-auto-columns with multiple raw 1fr values is rejected once',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-auto-columns: minmax(0, 1fr) 1fr; }',
+      description:
+        'grid-auto-columns with a raw 1fr alongside a protected minmax() is rejected',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: 1fr; grid-auto-columns: 1fr; }',
+      description:
+        'both grid-template-columns and grid-auto-columns are reported independently',
+      warnings: [{ message: messages.rejected() }, { message: messages.rejected() }],
+    },
+  ],
+  /* eslint-enable sort-keys */
+});
+
+/* Test the default configuration with autofix enabled */
+testRule({
+  config: [true],
+  fix: true,
+  ruleName: name,
+  /* eslint-disable sort-keys */
+  accept: [
+    {
+      code: '.class { grid-template-columns: minmax(0, 1fr) 250px; }',
+      description: 'already safe minmax(0, 1fr) is left unchanged',
+    },
+  ],
+  reject: [
+    {
+      code: '.class { grid-template-columns: 1fr 250px; }',
+      fixed: '.class { grid-template-columns: minmax(0, 1fr) 250px; }',
+      description: 'fix a single raw 1fr to minmax(0, 1fr)',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: 1fr 1fr 1fr; }',
+      fixed:
+        '.class { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr); }',
+      description: 'fix every raw 1fr to minmax(0, 1fr)',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: repeat(3, 1fr); }',
+      fixed: '.class { grid-template-columns: repeat(3, minmax(0, 1fr)); }',
+      description: 'fix a raw 1fr inside repeat()',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: minmax(0, 1fr) 1fr; }',
+      fixed: '.class { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }',
+      description: 'fix only the raw 1fr and leave the protected minmax() untouched',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: repeat(auto-fit, 1fr); }',
+      fixed: '.class { grid-template-columns: repeat(auto-fit, minmax(0, 1fr)); }',
+      description: 'fix a raw 1fr inside an auto-fit repeat()',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: repeat(auto-fill, 1fr); }',
+      fixed: '.class { grid-template-columns: repeat(auto-fill, minmax(0, 1fr)); }',
+      description: 'fix a raw 1fr inside an auto-fill repeat()',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: repeat(2, minmax(0, 1fr)) 1fr; }',
+      fixed:
+        '.class { grid-template-columns: repeat(2, minmax(0, 1fr)) minmax(0, 1fr); }',
+      description: 'fix only the raw 1fr after a protected repeat()',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-template-columns: minmax(0, 1fr) minmax(100px, 1fr) 1fr; }',
+      fixed:
+        '.class { grid-template-columns: minmax(0, 1fr) minmax(100px, 1fr) minmax(0, 1fr); }',
+      description: 'fix only the raw 1fr among multiple protected minmax() values',
+      message: messages.rejected(),
+    },
+    {
+      code: '.class { grid-auto-columns: 1fr; }',
+      fixed: '.class { grid-auto-columns: minmax(0, 1fr); }',
+      description: 'fix a raw 1fr on grid-auto-columns',
+      message: messages.rejected(),
+    },
+  ],
+  /* eslint-enable sort-keys */
+});
+
+/* Test the ignore configuration */
+testRule({
+  config: [true, { ignore: [/^\.grid-/, '.legacy-layout'] }],
+  ruleName: name,
+  /* eslint-disable sort-keys */
+  accept: [
+    {
+      code: '.legacy-layout { grid-template-columns: 1fr 250px; }',
+      description: 'ignored selector with exact string match is not flagged',
+    },
+    {
+      code: '.grid-wrapper { grid-template-columns: 1fr; }',
+      description: 'selector matching regex pattern is ignored',
+    },
+    {
+      code: '.grid-wrapper { grid-auto-columns: 1fr 1fr; }',
+      description: 'grid-auto-columns on an ignored selector is not flagged',
+    },
+    {
+      code: '.grid-wrapper { .child { grid-template-columns: 1fr; } }',
+      description:
+        'declaration nested inside an ignored ancestor selector is not flagged',
+    },
+    {
+      code: '.wrapper { .legacy-layout { grid-template-columns: 1fr 250px; } }',
+      description:
+        'declaration nested inside an ignored ancestor with an exact match is not flagged',
+    },
+  ],
+  reject: [
+    {
+      code: '.other { grid-template-columns: 1fr 250px; }',
+      description: 'non-ignored selector is still flagged',
+      message: messages.rejected(),
+    },
+    {
+      code: '.layout-grid { grid-template-columns: 1fr; }',
+      description: 'selector not matching the anchored regex pattern is still flagged',
+      message: messages.rejected(),
+    },
+    {
+      code: '.wrapper { .child { grid-template-columns: minmax(0, 1fr) 1fr; } }',
+      description:
+        'raw 1fr is still flagged when no ancestor selector matches the ignore pattern',
+      message: messages.rejected(),
+    },
+  ],
+  /* eslint-enable sort-keys */
+});

--- a/src/rules/require-grid-minmax/rule.ts
+++ b/src/rules/require-grid-minmax/rule.ts
@@ -1,0 +1,92 @@
+/**
+ * @author Daniel Yuschick
+ * @fileoverview Rule to help prevent grid content blowouts by enforcing the use of minmax() for '1fr' values.
+ * @license MIT
+ */
+
+import stylelint, { Rule } from 'stylelint';
+import { messages, meta, name } from './meta';
+import { fixOption, FixProps, severityOption, SeverityProps } from '../../utils/types';
+import { matchesIgnorePattern } from '../../utils/ignore';
+import { hasMatchingAncestor } from '../../utils/traversal';
+
+const { report, validateOptions } = stylelint.utils;
+
+interface SecondaryOptions extends SeverityProps, FixProps {
+  ignore?: (string | RegExp)[];
+}
+
+export const requireGridMinmax: Rule = (
+  primaryOption,
+  secondaryOptions: SecondaryOptions = {},
+) => {
+  return (root, result) => {
+    const validOptions = validateOptions(
+      result,
+      name,
+      {
+        actual: primaryOption,
+        possible: [true, false],
+      },
+      {
+        actual: secondaryOptions,
+        optional: true,
+        possible: {
+          ignore: [
+            (value: unknown) => {
+              return typeof value === 'string' || value instanceof RegExp;
+            },
+          ],
+          ...severityOption,
+          ...fixOption,
+        },
+      },
+    );
+
+    if (!validOptions) return;
+
+    const { ignore = [], severity } = secondaryOptions;
+
+    root.walkDecls(/grid-template-columns|grid-auto-columns/, (decl) => {
+      /* Skip the declaration if any ancestor selector should be ignored */
+      if (
+        hasMatchingAncestor(decl, (ancestor) => {
+          return (
+            ancestor.type === 'rule' && matchesIgnorePattern(ancestor.selector, ignore)
+          );
+        })
+      ) {
+        return;
+      }
+
+      /* Strip out any minmax() or fit-content() functions so their '1fr' values are ignored */
+      const unprotectedValue = decl.value.replace(/\b(minmax|fit-content)\([^)]*\)/g, '');
+
+      /* If no raw '1fr' values remain outside of those functions, return early */
+      if (!unprotectedValue.includes('1fr')) {
+        return;
+      }
+
+      /* A raw '1fr' value has been found, report and fix only the unprotected values */
+      const fix = () => {
+        decl.value = decl.value.replace(
+          /\b(minmax|fit-content)\([^)]*\)|1fr/g,
+          (match) => (match === '1fr' ? 'minmax(0, 1fr)' : match),
+        );
+      };
+
+      report({
+        fix,
+        message: messages.rejected(),
+        node: decl,
+        result,
+        ruleName: name,
+        severity,
+      });
+    });
+  };
+};
+
+requireGridMinmax.ruleName = name;
+requireGridMinmax.messages = messages;
+requireGridMinmax.meta = meta;


### PR DESCRIPTION
## 📒 Description

adds the new rule `require-grid-minmax` to lint for loose `1fr` values inside of `grid-template-columns` and `grid-auto-columns` properties

## 🚀 Changes

- adds the new `require-grid-minmax` rule
- adds test coverage for the rule
- adds documentation for the rule

## 🔐 Closes

#207 

## ⛳️ Testing

- ran `npm run test` to verify all tests pass