### PR TITLE
Fix: PostCSS Parser as Dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "stylelint-plugin-defensive-css",
       "version": "2.9.4",
       "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@release-it/conventional-changelog": "^10.0.4",
@@ -18,7 +21,6 @@
         "eslint-plugin-prettier": "^5.5.5",
         "globals": "^17.2.0",
         "jiti": "^2.6.1",
-        "postcss-selector-parser": "^7.1.1",
         "prettier": "^3.8.1",
         "release-it": "^19.2.4",
         "stylelint": "^16.1.0",
@@ -3609,7 +3611,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -5994,7 +5995,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -7569,7 +7569,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "test": "vitest",
     "test:watch": "vitest --watch"
   },
+  "dependencies": {
+    "postcss-selector-parser": "^7.1.1"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@release-it/conventional-changelog": "^10.0.4",
@@ -51,7 +54,6 @@
     "eslint-plugin-prettier": "^5.5.5",
     "globals": "^17.2.0",
     "jiti": "^2.6.1",
-    "postcss-selector-parser": "^7.1.1",
     "prettier": "^3.8.1",
     "release-it": "^19.2.4",
     "stylelint": "^16.1.0",


### PR DESCRIPTION
## 📒 Description

- moves `postcss-selector-parser` from `devDependency` into `dependencies`

## 🚀 Changes

- moves `postcss-selector-parser` from `devDependency` into `dependencies`
- updates package lock file

## 🔐 Closes

#218 

## ⛳️ Testing
